### PR TITLE
Feature: Support set google auth options when initialize VertexAI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 /* tslint:disable */
-import {GoogleAuth} from 'google-auth-library';
+import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 
 import {processNonStream, processStream} from './process_stream';
 import {
@@ -47,11 +47,12 @@ export class VertexAI {
    * @param{VertexInit} init - {@link VertexInit} 
    *       assign authentication related information to instantiate a Vertex AI client.
    */
-  constructor(init: VertexInit) {
+  constructor(init: VertexInit, auth?: GoogleAuthOptions) {
     this.preview = new VertexAI_Internal(
       init.project,
       init.location,
-      init.apiEndpoint
+      init.apiEndpoint,
+      auth
     );
   }
 }
@@ -60,9 +61,7 @@ export class VertexAI {
  * VertexAI class internal implementation for authentication.
 */
 export class VertexAI_Internal {
-  protected googleAuth: GoogleAuth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/cloud-platform',
-  });
+  protected googleAuth: GoogleAuth;
   private tokenInternalPromise?: Promise<any>;
 
   /**
@@ -76,11 +75,16 @@ export class VertexAI_Internal {
   constructor(
     readonly project: string,
     readonly location: string,
-    readonly apiEndpoint?: string
+    readonly apiEndpoint?: string,
+    readonly auth?: GoogleAuthOptions
   ) {
     this.project = project;
     this.location = location;
     this.apiEndpoint = apiEndpoint;
+    this.googleAuth = new GoogleAuth({
+      scopes: 'https://www.googleapis.com/auth/cloud-platform',
+      ...auth
+    });
   }
 
   /**

--- a/src/process_stream.ts
+++ b/src/process_stream.ts
@@ -99,16 +99,15 @@ function aggregateResponses(
 ): GenerateContentResponse {
   const lastResponse = responses[responses.length - 1];
 
-  if (lastResponse === undefined) {
-    throw new Error(
-      'Error processing stream because the response is undefined'
-    );
-  }
-
   const aggregatedResponse: GenerateContentResponse = {
     candidates: [],
-    promptFeedback: lastResponse.promptFeedback,
+    promptFeedback: lastResponse && lastResponse.promptFeedback,
   };
+
+  if (responses.length === 0) {
+    return aggregatedResponse;
+  }
+
   for (const response of responses) {
     for (let i = 0; i < response.candidates.length; i++) {
       if (!aggregatedResponse.candidates[i]) {


### PR DESCRIPTION
### Reason:
When initializing the VertexAI object, we do not support placing the files required for google auth in the running machine, so we hope to initialize GoogleAuth by passing in the json data structure required by google auth.

### Use Case We Want:
```javascript
const { VertexAI } = require('@google-cloud/vertexai')

new VertexAI({ project, location, apiEndpoint }, { credentials: googleCredentialsJson }
```

### Google's `@google-cloud/vertexai` package supports this feature
[Supports incoming google auth data when initialize PredictionServiceClient](https://github.com/googleapis/google-cloud-node/blob/6db06cbbcac4bffd9dd8947356623e4d95e6ed46/packages/google-cloud-aiplatform/src/v1/prediction_service_client.ts#L76)
###### Use Case:
```javascript
const { v1: { PredictionServiceClient } } = require('@google-cloud/aiplatform')

new PredictionServiceClient({ apiEndpoint, credentials: googleCredentialsJson })
```