### PR TITLE
Feature: Support set google auth options when initialize VertexAI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 /* tslint:disable */
-import {GoogleAuth} from 'google-auth-library';
+import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 
 import {
   processCountTokenResponse,
@@ -56,7 +56,7 @@ export class VertexAI {
    *     including project and location string, to instantiate a Vertex AI
    * client.
    */
-  constructor(init: VertexInit) {
+  constructor(init: VertexInit, authOptions?: GoogleAuthOptions) {
     /**
      * preview property is used to access any SDK methods available in public
      * preview, currently all functionality.
@@ -64,7 +64,8 @@ export class VertexAI {
     this.preview = new VertexAI_Preview(
       init.project,
       init.location,
-      init.apiEndpoint
+      init.apiEndpoint,
+      authOptions
     );
   }
 }
@@ -73,9 +74,7 @@ export class VertexAI {
  * VertexAI class internal implementation for authentication.
  */
 export class VertexAI_Preview {
-  protected googleAuth: GoogleAuth = new GoogleAuth({
-    scopes: 'https://www.googleapis.com/auth/cloud-platform',
-  });
+  protected googleAuth: GoogleAuth;
 
   /**
    * @constructor
@@ -88,11 +87,16 @@ export class VertexAI_Preview {
   constructor(
     readonly project: string,
     readonly location: string,
-    readonly apiEndpoint?: string
+    readonly apiEndpoint?: string,
+    readonly authOptions?: GoogleAuthOptions
   ) {
     this.project = project;
     this.location = location;
     this.apiEndpoint = apiEndpoint;
+    this.googleAuth = new GoogleAuth({
+      scopes: 'https://www.googleapis.com/auth/cloud-platform',
+      ...authOptions,
+    });
   }
 
   /**


### PR DESCRIPTION
### Reason:
When initializing the VertexAI object, we do not support placing the files required for google auth in the running machine, so we hope to initialize GoogleAuth by passing in the json data structure required by google auth.
### Use Case We Want:
```javascript
const { VertexAI } = require('@google-cloud/vertexai')

new VertexAI({ project, location, apiEndpoint }, { credentials: googleCredentialsJson }
```
### Google's `@google-cloud/vertexai` package supports this feature
[Supports incoming google auth data when initialize PredictionServiceClient](https://github.com/googleapis/google-cloud-node/blob/6db06cbbcac4bffd9dd8947356623e4d95e6ed46/packages/google-cloud-aiplatform/src/v1/prediction_service_client.ts#L76)
###### Use Case:
```javascript
const { v1: { PredictionServiceClient } } = require('@google-cloud/aiplatform')

new PredictionServiceClient({ apiEndpoint, credentials: googleCredentialsJson })
```