### PR TITLE
[Fix Issue 202] Support gemini finetuned models

### DIFF
--- a/src/models/generative_models.ts
+++ b/src/models/generative_models.ts
@@ -80,7 +80,10 @@ export class GenerativeModel {
       getGenerativeModelParams.systemInstruction.role = constants.SYSTEM_ROLE;
     }
     this.systemInstruction = getGenerativeModelParams.systemInstruction;
-    if (this.model.startsWith('models/')) {
+    this.systemInstruction = getGenerativeModelParams.systemInstruction;
+    if (this.model.startsWith('endpoints/')) {
+      this.publisherModelEndpoint = this.model;
+    } else if (this.model.startsWith('models/')) {
       this.publisherModelEndpoint = `publishers/google/${this.model}`;
     } else {
       this.publisherModelEndpoint = `publishers/google/models/${this.model}`;


### PR DESCRIPTION
We are now allowing the use of custom fine-tuned gemini models

Just ensure that you use model like `const model = endpoints/4178713732571987968`

```
const {VertexAI} = require('@google-cloud/vertexai');

// Initialize Vertex with your Cloud project and location
const vertex_ai = new VertexAI({project: '1046216570632', location: 'us-central1'});
const model = 'endpoints/4178713732571987968';

// Instantiate the models
const generativeModel = vertex_ai.preview.getGenerativeModel({
  model: model,
  generationConfig: {
    'maxOutputTokens': 2048,
    'temperature': 1,
    'topP': 1,
  },
  safetySettings: [
    {
        'category': 'HARM_CATEGORY_HATE_SPEECH',
        'threshold': 'BLOCK_MEDIUM_AND_ABOVE'
    },
    {
        'category': 'HARM_CATEGORY_DANGEROUS_CONTENT',
        'threshold': 'BLOCK_MEDIUM_AND_ABOVE'
    },
    {
        'category': 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
        'threshold': 'BLOCK_MEDIUM_AND_ABOVE'
    },
    {
        'category': 'HARM_CATEGORY_HARASSMENT',
        'threshold': 'BLOCK_MEDIUM_AND_ABOVE'
    }
  ],
});

<... rest of your generated code>
```