### PR TITLE
docs: provide custom serving stem for documentation generator

### DIFF
--- a/.kokoro/presubmit/node18/docs.sh
+++ b/.kokoro/presubmit/node18/docs.sh
@@ -32,7 +32,7 @@ npm install --no-save @google-cloud/cloud-rad@^0.4.0
 set +e
 
 # publish docs to devsite
-NO_UPLOAD=1 npx @google-cloud/cloud-rad . cloud-rad
+NO_UPLOAD=1 DOCS_METADATA_STEM=/vertex-ai/generative-ai/docs/reference/nodejs npx @google-cloud/cloud-rad . cloud-rad
 
 tar cvfz docs.tar.gz yaml
 

--- a/.kokoro/release/docs-devsite.sh
+++ b/.kokoro/release/docs-devsite.sh
@@ -28,4 +28,4 @@ fi
 npm install
 npm install --no-save @google-cloud/cloud-rad@^0.4.0
 # publish docs to devsite
-npx @google-cloud/cloud-rad . cloud-rad
+DOCS_METADATA_STEM=/vertex-ai/generative-ai/docs/reference/nodejs npx @google-cloud/cloud-rad . cloud-rad


### PR DESCRIPTION
Towards b/339671214, this is to host this package's documentation on a custom serving path. The output `docs.metadata` file will contain a custom stem: `/vertex-ai/generative-ai/docs/reference/nodejs`