### PR TITLE
feat: add support for audioTimestamp in GenerationConfig

### DIFF
--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -191,6 +191,8 @@ export interface ResponseSchema extends Schema {}
  * Configuration options for model generation and outputs.
  */
 export declare interface GenerationConfig {
+  /** Optional. If true, the timestamp of the audio will be included in the response. */
+  audioTimestamp?: boolean;
   /** Optional. Number of candidates to generate. */
   candidateCount?: number;
   /** Optional. Stop sequences. */


### PR DESCRIPTION
Adding support for the `audioTimestamp` to the GenerationConfig. This is already supported in the [Python SDK](https://github.com/googleapis/python-aiplatform/blob/4135810abbd3d134a6f0818e65581c74df0241ee/vertexai/generative_models/_generative_models.py#L1692) and [the documentation references it](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding#audio_transcription):

> The following shows you how to use an audio file to transcribe an interview. To enable timestamp understanding for audio-only files, enable the audioTimestamp parameter in GenerationConfig.
