### PR TITLE
fix: include cachedContent in generate request

### DIFF
--- a/src/models/chat_session.ts
+++ b/src/models/chat_session.ts
@@ -339,20 +339,21 @@ export class ChatSessionPreview {
   ): Promise<GenerateContentResult> {
     const newContent: Content[] =
       formulateNewContentFromSendMessageRequest(request);
-    const generateContentrequest: GenerateContentRequest = {
+    const generateContentRequest: GenerateContentRequest = {
       contents: this.historyInternal.concat(newContent),
       safetySettings: this.safetySettings,
       generationConfig: this.generationConfig,
       tools: this.tools,
       toolConfig: this.toolConfig,
       systemInstruction: this.systemInstruction,
+      cachedContent: this.cachedContent,
     };
 
     const generateContentResult: GenerateContentResult = await generateContent(
       this.location,
       this.resourcePath,
       this.fetchToken(),
-      generateContentrequest,
+      generateContentRequest,
       this.apiEndpoint,
       this.generationConfig,
       this.safetySettings,


### PR DESCRIPTION
This PR fixes context caching for non-streamed generate requests. I was hitting this as a bug when integrating a caching feature into firebase genkit with this SDK. I have manually tested this as a patch and it fixed my issue.