### PR TITLE
Use contentCache on vertexai preview generateContent request

### DIFF
--- a/src/models/generative_models.ts
+++ b/src/models/generative_models.ts
@@ -367,7 +367,7 @@ export class GenerativeModelPreview {
         request,
         this.systemInstruction
       ),
-      cachedContent: this.cachedContent?.name,
+      cachedContent: request.cachedContent,
     };
     return generateContent(
       this.location,

--- a/src/models/generative_models.ts
+++ b/src/models/generative_models.ts
@@ -297,7 +297,7 @@ export class GenerativeModelPreview {
   private readonly publisherModelEndpoint: string;
   private readonly resourcePath: string;
   private readonly apiEndpoint?: string;
-  private cachedContent?: CachedContent;
+  private readonly cachedContent?: CachedContent;
 
   /**
    * @constructor

--- a/src/models/generative_models.ts
+++ b/src/models/generative_models.ts
@@ -297,7 +297,7 @@ export class GenerativeModelPreview {
   private readonly publisherModelEndpoint: string;
   private readonly resourcePath: string;
   private readonly apiEndpoint?: string;
-  private readonly cachedContent?: CachedContent;
+  private cachedContent?: CachedContent;
 
   /**
    * @constructor

--- a/src/vertex_ai.ts
+++ b/src/vertex_ai.ts
@@ -215,7 +215,6 @@ class VertexAIPreview {
       toolConfig: modelParams.toolConfig,
       requestOptions: requestOptions,
       systemInstruction: modelParams.systemInstruction,
-      cachedContent: modelParams.cachedContent,
     };
     return new GenerativeModelPreview(getGenerativeModelParams);
   }

--- a/src/vertex_ai.ts
+++ b/src/vertex_ai.ts
@@ -215,6 +215,7 @@ class VertexAIPreview {
       toolConfig: modelParams.toolConfig,
       requestOptions: requestOptions,
       systemInstruction: modelParams.systemInstruction,
+      cachedContent: modelParams.cachedContent,
     };
     return new GenerativeModelPreview(getGenerativeModelParams);
   }


### PR DESCRIPTION
- Actually pass  `modelParams.cachedContent` to `GenerativeModelPreview()` which sets `this.contentCache`
- Use `request.cachedContent` when calling preview `generateContent()` 