### PR TITLE
Use cacheContent when using VertexAIPreview generateContent

### DIFF
--- a/src/models/generative_models.ts
+++ b/src/models/generative_models.ts
@@ -367,7 +367,7 @@ export class GenerativeModelPreview {
         request,
         this.systemInstruction
       ),
-      cachedContent: this.cachedContent?.name,
+      cachedContent: request.cachedContent?.name,
     };
     return generateContent(
       this.location,

--- a/src/vertex_ai.ts
+++ b/src/vertex_ai.ts
@@ -215,6 +215,7 @@ class VertexAIPreview {
       toolConfig: modelParams.toolConfig,
       requestOptions: requestOptions,
       systemInstruction: modelParams.systemInstruction,
+      cachedContent: modelParams.cachedContent,
     };
     return new GenerativeModelPreview(getGenerativeModelParams);
   }


### PR DESCRIPTION
- Actually pass modelParams.cachedContent to GenerativeModelPreview() which sets this.contentCache
- Use request.cachedContent when calling preview generateContent()