### PR TITLE
fix: aggregate text & functionCall(s) correctly

### DIFF
--- a/src/functions/post_fetch_processing.ts
+++ b/src/functions/post_fetch_processing.ts
@@ -249,17 +249,21 @@ export function aggregateResponses(
         response.candidates[i].content.parts &&
         response.candidates[i].content.parts.length > 0
       ) {
+        const {parts} = aggregatedResponse.candidates[i].content;
         for (const part of response.candidates[i].content.parts) {
+          // NOTE: cannot have text and functionCall both in the same part.
+          // add functionCall(s) to new parts. When done, if the text is
+          // empty then remove the text part
           if (part.text) {
-            aggregatedResponse.candidates[i].content.parts[0].text += part.text;
+            parts[0].text += part.text;
           }
           if (part.functionCall) {
-            aggregatedResponse.candidates[i].content.parts[0].functionCall =
-              part.functionCall;
-            // the empty 'text' key should be removed if functionCall is in the
-            // response
-            delete aggregatedResponse.candidates[i].content.parts[0].text;
+            parts.push({functionCall: part.functionCall});
           }
+        }
+
+        if (parts.length > 1 && !parts[0].text) {
+          parts.shift();
         }
       }
       const groundingMetadataAggregated: GroundingMetadata | undefined =

--- a/src/functions/post_fetch_processing.ts
+++ b/src/functions/post_fetch_processing.ts
@@ -252,18 +252,13 @@ export function aggregateResponses(
         const {parts} = aggregatedResponse.candidates[i].content;
         for (const part of response.candidates[i].content.parts) {
           // NOTE: cannot have text and functionCall both in the same part.
-          // add functionCall(s) to new parts. When done, if the text is
-          // empty then remove the text part
+          // add functionCall(s) to new parts.
           if (part.text) {
             parts[0].text += part.text;
           }
           if (part.functionCall) {
             parts.push({functionCall: part.functionCall});
           }
-        }
-
-        if (parts.length > 1 && !parts[0].text) {
-          parts.shift();
         }
       }
       const groundingMetadataAggregated: GroundingMetadata | undefined =

--- a/src/functions/post_fetch_processing.ts
+++ b/src/functions/post_fetch_processing.ts
@@ -273,8 +273,11 @@ export function aggregateResponses(
     }
   }
   if (aggregatedResponse.candidates?.length) {
-    aggregatedResponse.candidates.forEach((candidate) => {
-      if (candidate.content.parts.length > 1 && candidate.content.parts[0].text === '') {
+    aggregatedResponse.candidates.forEach(candidate => {
+      if (
+        candidate.content.parts.length > 1 &&
+        candidate.content.parts[0].text === ''
+      ) {
         candidate.content.parts.shift(); // remove empty text parameter
       }
     });

--- a/src/functions/post_fetch_processing.ts
+++ b/src/functions/post_fetch_processing.ts
@@ -272,6 +272,13 @@ export function aggregateResponses(
       }
     }
   }
+  if (aggregatedResponse.candidates?.length) {
+    aggregatedResponse.candidates.forEach((candidate) => {
+      if (candidate.content.parts.length > 1 && candidate.content.parts[0].text === '') {
+        candidate.content.parts.shift(); // remove empty text parameter
+      }
+    });
+  }
   return aggregatedResponse;
 }
 

--- a/src/functions/test/post_fetch_processing_test.ts
+++ b/src/functions/test/post_fetch_processing_test.ts
@@ -20,11 +20,15 @@ import {
   AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_2,
   AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_3,
   AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_4,
+  AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_5,
+  AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_6,
   COUNT_TOKENS_RESPONSE_1,
   STREAM_RESPONSE_CHUNKS_1,
   STREAM_RESPONSE_CHUNKS_2,
   STREAM_RESPONSE_CHUNKS_3,
   STREAM_RESPONSE_CHUNKS_4,
+  STREAM_RESPONSE_CHUNKS_5,
+  STREAM_RESPONSE_CHUNKS_6,
   UNARY_RESPONSE_1,
   UNARY_RESPONSE_MISSING_ROLE_INDEX,
 } from './test_data';
@@ -82,6 +86,22 @@ describe('aggregateResponses', () => {
 
     expect(JSON.stringify(actualResult)).toEqual(
       JSON.stringify(AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_4)
+    );
+  });
+
+  it('should aggregate text and functionCalls to separate parts', () => {
+    const actualResult = aggregateResponses(STREAM_RESPONSE_CHUNKS_5);
+
+    expect(JSON.stringify(actualResult)).toEqual(
+      JSON.stringify(AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_5)
+    );
+  });
+
+  it('should aggregate functionCalls with the empty text removed', () => {
+    const actualResult = aggregateResponses(STREAM_RESPONSE_CHUNKS_6);
+
+    expect(JSON.stringify(actualResult)).toEqual(
+      JSON.stringify(AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_6)
     );
   });
 });

--- a/src/functions/test/test_data.ts
+++ b/src/functions/test/test_data.ts
@@ -911,9 +911,19 @@ export const STREAM_RESPONSE_CHUNKS_5: GenerateContentResponse[] = [
       {
         content: {
           parts: [
-            {text: 'chunk1Text1'},
             {functionCall: {name: 'fn', args: {a: 1}}},
-            {text: 'chunk1Text2'},
+            {text: 'chunk1Text1'},
+          ],
+        },
+      },
+    ],
+  },
+  {
+    candidates: [
+      {
+        content: {
+          parts: [
+            {text: 'chunk2Text1'},
           ],
         },
       },
@@ -929,7 +939,7 @@ export const AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_5: GenerateContentRespon
         content: {
           role: 'model',
           parts: [
-            {text: 'chunk1Text1chunk1Text2'},
+            {text: 'chunk1Text1chunk2Text1'},
             {functionCall: {name: 'fn', args: {a: 1}}},
           ],
         },
@@ -956,7 +966,9 @@ export const AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_6: GenerateContentRespon
         index: 0,
         content: {
           role: 'model',
-          parts: [{functionCall: {name: 'fn', args: {a: 1}}}],
+          parts: [
+            {text: ''},
+            {functionCall: {name: 'fn', args: {a: 1}}}],
         },
       },
     ],

--- a/src/functions/test/test_data.ts
+++ b/src/functions/test/test_data.ts
@@ -905,6 +905,63 @@ export const AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_4: GenerateContentRespon
     ],
   } as GenerateContentResponse;
 
+export const STREAM_RESPONSE_CHUNKS_5: GenerateContentResponse[] = [
+  {
+    candidates: [
+      {
+        content: {
+          parts: [
+            {text: 'chunk1Text1'},
+            {functionCall: {name: 'fn', args: {a: 1}}},
+            {text: 'chunk1Text2'},
+          ],
+        },
+      },
+    ],
+  },
+] as GenerateContentResponse[];
+
+export const AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_5: GenerateContentResponse =
+  {
+    candidates: [
+      {
+        index: 0,
+        content: {
+          role: 'model',
+          parts: [
+            {text: 'chunk1Text1chunk1Text2'},
+            {functionCall: {name: 'fn', args: {a: 1}}},
+          ],
+        },
+      },
+    ],
+  } as GenerateContentResponse;
+
+export const STREAM_RESPONSE_CHUNKS_6: GenerateContentResponse[] = [
+  {
+    candidates: [
+      {
+        content: {
+          parts: [{functionCall: {name: 'fn', args: {a: 1}}}],
+        },
+      },
+    ],
+  },
+] as GenerateContentResponse[];
+
+export const AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_6: GenerateContentResponse =
+  {
+    candidates: [
+      {
+        index: 0,
+        content: {
+          role: 'model',
+          parts: [{functionCall: {name: 'fn', args: {a: 1}}}],
+        },
+      },
+    ],
+  } as GenerateContentResponse;
+
 export const UNARY_RESPONSE_1: GenerateContentResponse = {
   candidates: [
     {

--- a/src/functions/test/test_data.ts
+++ b/src/functions/test/test_data.ts
@@ -922,9 +922,7 @@ export const STREAM_RESPONSE_CHUNKS_5: GenerateContentResponse[] = [
     candidates: [
       {
         content: {
-          parts: [
-            {text: 'chunk2Text1'},
-          ],
+          parts: [{text: 'chunk2Text1'}],
         },
       },
     ],
@@ -966,8 +964,7 @@ export const AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_6: GenerateContentRespon
         index: 0,
         content: {
           role: 'model',
-          parts: [
-            {functionCall: {name: 'fn', args: {a: 1}}}],
+          parts: [{functionCall: {name: 'fn', args: {a: 1}}}],
         },
       },
     ],

--- a/src/functions/test/test_data.ts
+++ b/src/functions/test/test_data.ts
@@ -967,7 +967,6 @@ export const AGGREGATED_RESPONSE_STREAM_RESPONSE_CHUNKS_6: GenerateContentRespon
         content: {
           role: 'model',
           parts: [
-            {text: ''},
             {functionCall: {name: 'fn', args: {a: 1}}}],
         },
       },


### PR DESCRIPTION
the content parts should have either `text` or `functionCall` set, but never both at once. When aggregating, combine the text (as before), but add `functionCall`(s) as new part(s). ~~Then when done, if the text from `part[0]` is empty, that part can be removed.~~ _(edit - I found that multiple responses were then resulting in the aggregate `undefined\n`, so now the empty text is always left as the first part)_

fixes #494