### PR TITLE
feat: add unique id to chat history items

### DIFF
--- a/src/models/chat_session.ts
+++ b/src/models/chat_session.ts
@@ -126,8 +126,10 @@ export class ChatSession {
   async sendMessage(
     request: string | Array<string | Part>
   ): Promise<GenerateContentResult> {
-    const newContent: Content[] =
-      formulateNewContentFromSendMessageRequest(request);
+    const newContent: Content[] = formulateNewContentFromSendMessageRequest(
+      request,
+      this.historyInternal
+    );
     const generateContentRequest: GenerateContentRequest = {
       contents: this.historyInternal.concat(newContent),
       safetySettings: this.safetySettings,
@@ -211,8 +213,10 @@ export class ChatSession {
   async sendMessageStream(
     request: string | Array<string | Part>
   ): Promise<StreamGenerateContentResult> {
-    const newContent: Content[] =
-      formulateNewContentFromSendMessageRequest(request);
+    const newContent: Content[] = formulateNewContentFromSendMessageRequest(
+      request,
+      this.historyInternal
+    );
     const generateContentrequest: GenerateContentRequest = {
       contents: this.historyInternal.concat(newContent),
       safetySettings: this.safetySettings,
@@ -337,8 +341,10 @@ export class ChatSessionPreview {
   async sendMessage(
     request: string | Array<string | Part>
   ): Promise<GenerateContentResult> {
-    const newContent: Content[] =
-      formulateNewContentFromSendMessageRequest(request);
+    const newContent: Content[] = formulateNewContentFromSendMessageRequest(
+      request,
+      this.historyInternal
+    );
     const generateContentRequest: GenerateContentRequest = {
       contents: this.historyInternal.concat(newContent),
       safetySettings: this.safetySettings,
@@ -424,8 +430,10 @@ export class ChatSessionPreview {
   async sendMessageStream(
     request: string | Array<string | Part>
   ): Promise<StreamGenerateContentResult> {
-    const newContent: Content[] =
-      formulateNewContentFromSendMessageRequest(request);
+    const newContent: Content[] = formulateNewContentFromSendMessageRequest(
+      request,
+      this.historyInternal
+    );
     const generateContentRequest: GenerateContentRequest = {
       contents: this.historyInternal.concat(newContent),
       safetySettings: this.safetySettings,
@@ -464,7 +472,8 @@ export class ChatSessionPreview {
 }
 
 function formulateNewContentFromSendMessageRequest(
-  request: string | Array<string | Part>
+  request: string | Array<string | Part>,
+  historyInternal: Content[]
 ): Content[] {
   let newParts: Part[] = [];
 
@@ -480,7 +489,10 @@ function formulateNewContentFromSendMessageRequest(
     }
   }
 
-  return assignRoleToPartsAndValidateSendMessageRequest(newParts);
+  return assignRoleToPartsAndValidateSendMessageRequest(
+    newParts,
+    historyInternal
+  );
 }
 
 /**
@@ -492,10 +504,15 @@ function formulateNewContentFromSendMessageRequest(
  * @returns Array of content items
  */
 function assignRoleToPartsAndValidateSendMessageRequest(
-  parts: Array<Part>
+  parts: Array<Part>,
+  historyInternal: Content[]
 ): Content[] {
-  const userContent: Content = {role: constants.USER_ROLE, parts: []};
-  const functionContent: Content = {role: constants.USER_ROLE, parts: []};
+  let id: string = crypto.randomUUID();
+  while (historyInternal.some(content => content.id === id)) {
+    id = crypto.randomUUID();
+  }
+  const userContent: Content = {id, role: constants.USER_ROLE, parts: []};
+  const functionContent: Content = {id, role: constants.USER_ROLE, parts: []};
   let hasUserContent = false;
   let hasFunctionContent = false;
   for (const part of parts) {

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -315,6 +315,8 @@ export declare interface Content {
   parts: Part[];
   /** The producer of the content. */
   role: string;
+  /** The unique id  if the content */
+  id?: string;
 }
 
 /**

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -315,7 +315,7 @@ export declare interface Content {
   parts: Part[];
   /** The producer of the content. */
   role: string;
-  /** The unique id  if the content */
+  /** The unique id of the content */
   id?: string;
 }
 


### PR DESCRIPTION
Adds unique id's to chat history items to make manipulating history easier and less error prone. The `id` is optional in the `Content` type to avoid breaking typescript projects. I'm on the fence as to whether this should not be optional, but it seems like making it mandatory would be a breaking change. I'm fine with this being a breaking change but wanted to first introduce the least disruptive change. There may be ramifications I'm not thinking of by making the `id` optional.