### PR TITLE
feat: expose error status code

### DIFF
--- a/src/functions/post_fetch_processing.ts
+++ b/src/functions/post_fetch_processing.ts
@@ -43,19 +43,16 @@ export async function throwErrorIfNotOK(response: Response | undefined) {
     const errorMessage = `got status: ${status} ${statusText}. ${JSON.stringify(
       errorBody
     )}`;
+    const apiError = new GoogleApiError(
+      errorBody.error.message,
+      errorBody.error.code,
+      errorBody.error.status,
+      errorBody.error.details
+    );
     if (status >= 400 && status < 500) {
-      const error = new ClientError(
-        errorMessage,
-        new GoogleApiError(
-          errorBody.error.message,
-          errorBody.error.code,
-          errorBody.error.status,
-          errorBody.error.details
-        )
-      );
-      throw error;
+      throw new ClientError(errorMessage, apiError);
     }
-    throw new GoogleGenerativeAIError(errorMessage);
+    throw new GoogleGenerativeAIError(errorMessage, apiError);
   }
 }
 

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -34,11 +34,17 @@ class GoogleAuthError extends Error {
  */
 class ClientError extends Error {
   public readonly stackTrace?: Error;
+  public readonly statusCode?: number;
+
   constructor(message: string, stackTrace?: Error) {
     super(message, {cause: stackTrace});
     this.message = constructErrorMessage('ClientError', message);
     this.name = 'ClientError';
     this.stackTrace = stackTrace;
+
+    if (stackTrace instanceof GoogleApiError) {
+      this.statusCode = stackTrace.code;
+    }
   }
 }
 
@@ -76,11 +82,17 @@ class GoogleApiError extends Error {
  */
 class GoogleGenerativeAIError extends Error {
   public readonly stackTrace?: Error;
+  public readonly statusCode?: number;
+
   constructor(message: string, stackTrace?: Error) {
     super(message, {cause: stackTrace});
     this.message = constructErrorMessage('GoogleGenerativeAIError', message);
     this.name = 'GoogleGenerativeAIError';
     this.stackTrace = stackTrace;
+
+    if (stackTrace instanceof GoogleApiError) {
+      this.statusCode = stackTrace.code;
+    }
   }
 }
 


### PR DESCRIPTION
Exposes error status codes to the library user so that they don't have to be extracted from error message string.